### PR TITLE
Add two caveats to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,33 @@ unless that is already mapped to something else..
 
 The easiest way to install this is to use Pathogen and
 "git clone" this repository into the .vim/bundle directory.
+
+## Differences between arrow functions and the `function` keyword
+
+This plug-in will perform a simple transformation from a function declared with
+the `function` keyword to an arrow function expression. It is good to bear in
+mind the differences between these two expressions, so as to spot when the
+result is not exactly equivalent.
+
+The first caveat is that arrow function expressions automatically return the
+value of the last statement, whereas normal functions require the `return`
+statement:
+
+```javascript
+var example = function () { foobar(); }; // example() always returns null
+
+var example2 = () => { foobar(); }; // example2() will return the return value of foobar()
+```
+
+The other difference is that normal functions always receive a `this` value,
+whereas arrow functions inherit the `this` value from its context.
+
+```javascript
+$("a").each(function() { console.log(this); }; // logs "a" DOM elements
+
+$("a").each(() => { console.log(this); }; // logs the window object
+```
+
+Resources:
+
+- [Arrow functions blog post from hacks.mozilla.org](https://hacks.mozilla.org/2015/06/es6-in-depth-arrow-functions/)


### PR DESCRIPTION
Thanks for writing this plug-in, it looks useful!

I thought I would just add two caveats to the README file, so that developers new to arrow notation won't trip up over these gotchas.

I'm willing to license these changes under any open source license you choose.
